### PR TITLE
[Upgrade] to .NET 10, System.CommandLine 2.0 GA, ClosedXML CVE fix

### DIFF
--- a/.github/workflows/CodeQuality.yml
+++ b/.github/workflows/CodeQuality.yml
@@ -22,9 +22,7 @@ jobs:
       - name: Setup dotnet
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: |
-            8.0.x
-            10.0.x
+          dotnet-version: '10.0.x'
 
       - name: install VCD Generator
         run: dotnet tool install --global vcdg

--- a/.github/workflows/CodeQuality.yml
+++ b/.github/workflows/CodeQuality.yml
@@ -10,19 +10,21 @@ jobs:
     name: Build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
       - name: Set up JDK 17
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
           java-version: '17'
           overwrite-settings: false
       - name: Setup dotnet
-        uses: actions/setup-dotnet@v2
+        uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: '8.0.x'
+          dotnet-version: |
+            8.0.x
+            10.0.x
 
       - name: install VCD Generator
         run: dotnet tool install --global vcdg
@@ -53,7 +55,7 @@ jobs:
         run: vcdg -rf VCD-Generator.Tests/Data/Requirements-01.xlsx --requirements-sheet-name requirements --requirements-id-column Identifier --requirements-text-column "Requirement Text" --source-directory . --output-report vcd-report.xlsx
 
       - name: Archive results
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: vcd-report
           path: vcd-report.xlsx

--- a/VCD-Generator.Tests/Commands/GenerateCommandHandlerTestFixture.cs
+++ b/VCD-Generator.Tests/Commands/GenerateCommandHandlerTestFixture.cs
@@ -22,7 +22,6 @@ namespace VCD.Generator.Tests.Commands
 {
     using System;
     using System.Collections.Generic;
-    using System.CommandLine.Invocation;
     using System.IO;
     using System.Linq;
     using System.Threading.Tasks;
@@ -92,22 +91,9 @@ namespace VCD.Generator.Tests.Commands
         }
 
         [Test]
-        public void Verify_that_GenerateCommand_Invoke_throws_exception()
-        {
-            var invocationContext = new InvocationContext(null);
-
-            Assert.That(() =>
-            {
-                this.handler.Invoke(invocationContext);
-            }, Throws.TypeOf<NotSupportedException>());
-        }
-
-        [Test]
         public async Task Verify_that_InvokeAsync_returns_0()
         {
-            var invocationContext = new InvocationContext(null);
-
-            var result = await this.handler.InvokeAsync(invocationContext);
+            var result = await this.handler.InvokeAsync();
 
             this.requirementsReader.Verify(x =>
                 x.Read(It.IsAny<FileInfo>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()),
@@ -129,11 +115,9 @@ namespace VCD.Generator.Tests.Commands
         [Test]
         public async Task Verify_that_InvokeAsync_returns_minus_one_when_requirementsfile_does_not_exist()
         {
-            var invocationContext = new InvocationContext(null);
-
             this.handler.RequirementsFile = new FileInfo(TestContext.CurrentContext.TestDirectory);
 
-            var result = await this.handler.InvokeAsync(invocationContext);
+            var result = await this.handler.InvokeAsync();
 
             Assert.That(result, Is.EqualTo(-1));
         }
@@ -141,11 +125,9 @@ namespace VCD.Generator.Tests.Commands
         [Test]
         public async Task Verify_that_InvokeAsync_returns_minus_one_when_sourcedirectory_dooes_not_exist()
         {
-            var invocationContext = new InvocationContext(null);
-
             this.handler.SourceDirectory = new DirectoryInfo(@"z:\some-non-existing-directory");
 
-            var result = await this.handler.InvokeAsync(invocationContext);
+            var result = await this.handler.InvokeAsync();
 
             Assert.That(result, Is.EqualTo(-1));
         }

--- a/VCD-Generator.Tests/VCD-Generator.Tests.csproj
+++ b/VCD-Generator.Tests/VCD-Generator.Tests.csproj
@@ -37,7 +37,14 @@
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
+	</ItemGroup>
+
+	<ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
 		<PackageReference Include="Microsoft.Extensions.Logging.Console" Version="8.0.1" />
+	</ItemGroup>
+
+	<ItemGroup Condition="'$(TargetFramework)' == 'net10.0'">
+		<PackageReference Include="Microsoft.Extensions.Logging.Console" Version="10.0.6" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/VCD-Generator.Tests/VCD-Generator.Tests.csproj
+++ b/VCD-Generator.Tests/VCD-Generator.Tests.csproj
@@ -9,7 +9,7 @@
 
 	<PropertyGroup Label="Package">
 		<Description>Nunit test suite for the VCD.Generator library</Description>
-		<TargetFramework>net8.0</TargetFramework>
+		<TargetFrameworks>net8.0;net10.0</TargetFrameworks>
 		<RootNamespace>VCD.Generator.Tests</RootNamespace>
 		<ImplicitUsings>false</ImplicitUsings>
 		<Nullable>disable</Nullable>

--- a/VCD-Generator.Tests/VCD-Generator.Tests.csproj
+++ b/VCD-Generator.Tests/VCD-Generator.Tests.csproj
@@ -9,7 +9,7 @@
 
 	<PropertyGroup Label="Package">
 		<Description>Nunit test suite for the VCD.Generator library</Description>
-		<TargetFrameworks>net8.0;net10.0</TargetFrameworks>
+		<TargetFramework>net10.0</TargetFramework>
 		<RootNamespace>VCD.Generator.Tests</RootNamespace>
 		<ImplicitUsings>false</ImplicitUsings>
 		<Nullable>disable</Nullable>
@@ -39,11 +39,7 @@
 		</PackageReference>
 	</ItemGroup>
 
-	<ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
-		<PackageReference Include="Microsoft.Extensions.Logging.Console" Version="8.0.1" />
-	</ItemGroup>
-
-	<ItemGroup Condition="'$(TargetFramework)' == 'net10.0'">
+	<ItemGroup>
 		<PackageReference Include="Microsoft.Extensions.Logging.Console" Version="10.0.6" />
 	</ItemGroup>
 

--- a/VCD-Generator.Tests/VCD-Generator.Tests.csproj
+++ b/VCD-Generator.Tests/VCD-Generator.Tests.csproj
@@ -37,7 +37,7 @@
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
-		<PackageReference Include="Microsoft.Extensions.Logging.Console" Version="8.0.0" />
+		<PackageReference Include="Microsoft.Extensions.Logging.Console" Version="8.0.1" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/VCD-Generator/Commands/GenerateCommand.cs
+++ b/VCD-Generator/Commands/GenerateCommand.cs
@@ -1,7 +1,7 @@
 // -------------------------------------------------------------------------------------------------
 // <copyright file="GenerateCommand.cs" company="Starion Group S.A.">
 //
-//   Copyright 2022-2024 Starion Group S.A.
+//   Copyright 2022-2026 Starion Group S.A.
 //
 //   Licensed under the Apache License, Version 2.0 (the "License");
 //   you may not use this file except in compliance with the License.

--- a/VCD-Generator/Commands/GenerateCommand.cs
+++ b/VCD-Generator/Commands/GenerateCommand.cs
@@ -83,7 +83,6 @@ namespace VCD.Generator.Commands
             this.NoLogoOption = new Option<bool>("--no-logo")
             {
                 Description = "Suppress the logo",
-                DefaultValueFactory = _ => false,
             };
             this.Options.Add(this.NoLogoOption);
 
@@ -116,11 +115,7 @@ namespace VCD.Generator.Commands
             this.SourceDirectoryOption = new Option<DirectoryInfo>("--source-directory", "-sd")
             {
                 Description = "The directory that contains the test result files, this directory is process recursively",
-                DefaultValueFactory = _ =>
-                {
-                    var strExeFilePath = System.Reflection.Assembly.GetExecutingAssembly().Location;
-                    return new FileInfo(strExeFilePath).Directory;
-                },
+                DefaultValueFactory = _ => new DirectoryInfo(AppContext.BaseDirectory),
                 Required = true,
             };
             this.Options.Add(this.SourceDirectoryOption);

--- a/VCD-Generator/Commands/GenerateCommand.cs
+++ b/VCD-Generator/Commands/GenerateCommand.cs
@@ -1,20 +1,20 @@
-﻿// -------------------------------------------------------------------------------------------------
+// -------------------------------------------------------------------------------------------------
 // <copyright file="GenerateCommand.cs" company="Starion Group S.A.">
-// 
+//
 //   Copyright 2022-2024 Starion Group S.A.
-// 
+//
 //   Licensed under the Apache License, Version 2.0 (the "License");
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
-// 
+//
 //        http://www.apache.org/licenses/LICENSE-2.0
-// 
+//
 //    Unless required by applicable law or agreed to in writing, software
 //    distributed under the License is distributed on an "AS IS" BASIS,
 //    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 //    See the License for the specific language governing permissions and
 //    limitations under the License.
-// 
+//
 // </copyright>
 // ------------------------------------------------------------------------------------------------
 
@@ -23,7 +23,6 @@ namespace VCD.Generator.Commands
     using System;
     using System.Collections.Generic;
     using System.CommandLine;
-    using System.CommandLine.Invocation;
     using System.IO;
     using System.Linq;
     using System.Threading;
@@ -42,70 +41,123 @@ namespace VCD.Generator.Commands
     public class GenerateCommand : RootCommand
     {
         /// <summary>
+        /// The <see cref="Option{T}"/> to suppress the logo
+        /// </summary>
+        public Option<bool> NoLogoOption { get; }
+
+        /// <summary>
+        /// The <see cref="Option{T}"/> for the requirements spreadsheet file
+        /// </summary>
+        public Option<FileInfo> RequirementsFileOption { get; }
+
+        /// <summary>
+        /// The <see cref="Option{T}"/> for the name of the requirements sheet
+        /// </summary>
+        public Option<string> RequirementsSheetNameOption { get; }
+
+        /// <summary>
+        /// The <see cref="Option{T}"/> for the name of the requirements id column
+        /// </summary>
+        public Option<string> RequirementsIdColumnOption { get; }
+
+        /// <summary>
+        /// The <see cref="Option{T}"/> for the name of the requirements text column
+        /// </summary>
+        public Option<string> RequirementsTextColumnOption { get; }
+
+        /// <summary>
+        /// The <see cref="Option{T}"/> for the directory that contains the test result files
+        /// </summary>
+        public Option<DirectoryInfo> SourceDirectoryOption { get; }
+
+        /// <summary>
+        /// The <see cref="Option{T}"/> for the path of the generated report file
+        /// </summary>
+        public Option<FileInfo> OutputReportOption { get; }
+
+        /// <summary>
         /// Initializes a new instance of the <see cref="GenerateCommand"/>
         /// </summary>
         public GenerateCommand() : base("VCD Generator")
         {
-            var noLogoOption = new Option<bool>(
-                name: "--no-logo",
-                description: "Suppress the logo",
-                getDefaultValue: () => false);
-            this.AddOption(noLogoOption);
+            this.NoLogoOption = new Option<bool>("--no-logo")
+            {
+                Description = "Suppress the logo",
+                DefaultValueFactory = _ => false,
+            };
+            this.Options.Add(this.NoLogoOption);
 
-            var requirementsFileOption = new Option<FileInfo>(
-                name: "--requirements-file",
-                description: "The spreadsheet file that contains the requirements that need to be verified",
-                getDefaultValue: () => new FileInfo("requirements.xlsx"));
-            requirementsFileOption.AddAlias("-rf");
-            requirementsFileOption.IsRequired = true;
-            this.AddOption(requirementsFileOption);
+            this.RequirementsFileOption = new Option<FileInfo>("--requirements-file", "-rf")
+            {
+                Description = "The spreadsheet file that contains the requirements that need to be verified",
+                DefaultValueFactory = _ => new FileInfo("requirements.xlsx"),
+                Required = true,
+            };
+            this.Options.Add(this.RequirementsFileOption);
 
-            var requirementsSheetNameOption = new Option<string>(
-                name: "--requirements-sheet-name",
-                description: "The name of the requirements sheet in the spreadsheet file that is to be processed. If left empty then the first sheet in the workbook will be used.");
-            requirementsSheetNameOption.AddAlias("-sn");
-            requirementsSheetNameOption.IsRequired = false;
-            this.AddOption(requirementsSheetNameOption);
+            this.RequirementsSheetNameOption = new Option<string>("--requirements-sheet-name", "-sn")
+            {
+                Description = "The name of the requirements sheet in the spreadsheet file that is to be processed. If left empty then the first sheet in the workbook will be used.",
+            };
+            this.Options.Add(this.RequirementsSheetNameOption);
 
-            var identifierColumnNameOption = new Option<string>(
-                name:"--requirements-id-column",
-                description: "The name of the table-column that contains the identifier of the requirements. If left empty then the first column with content is used.");
-            identifierColumnNameOption.IsRequired = false;
-            identifierColumnNameOption.AddAlias("-id");
-            this.AddOption(identifierColumnNameOption);
+            this.RequirementsIdColumnOption = new Option<string>("--requirements-id-column", "-id")
+            {
+                Description = "The name of the table-column that contains the identifier of the requirements. If left empty then the first column with content is used.",
+            };
+            this.Options.Add(this.RequirementsIdColumnOption);
 
-            var textColumnNameOption = new Option<string>(
-                name: "--requirements-text-column",
-                description: "The name of the table-column that contains the text of the requirements. If left empty then the requirement text is ignored.");
-            textColumnNameOption.IsRequired = false;
-            textColumnNameOption.AddAlias("-txt");
-            this.AddOption(textColumnNameOption);
+            this.RequirementsTextColumnOption = new Option<string>("--requirements-text-column", "-txt")
+            {
+                Description = "The name of the table-column that contains the text of the requirements. If left empty then the requirement text is ignored.",
+            };
+            this.Options.Add(this.RequirementsTextColumnOption);
 
-            var testResultsFileOption = new Option<DirectoryInfo>(
-                name: "--source-directory",
-                description: "The directory that contains the test result files, this directory is process recursively",
-                getDefaultValue: () =>
+            this.SourceDirectoryOption = new Option<DirectoryInfo>("--source-directory", "-sd")
+            {
+                Description = "The directory that contains the test result files, this directory is process recursively",
+                DefaultValueFactory = _ =>
                 {
                     var strExeFilePath = System.Reflection.Assembly.GetExecutingAssembly().Location;
                     return new FileInfo(strExeFilePath).Directory;
-                });
-            testResultsFileOption.AddAlias("-sd");
-            testResultsFileOption.IsRequired = true;
-            this.AddOption(testResultsFileOption);
+                },
+                Required = true,
+            };
+            this.Options.Add(this.SourceDirectoryOption);
 
-            var reportFileOption = new Option<FileInfo>(
-                name: "--output-report",
-                description: "The path to the report file",
-                getDefaultValue: () => new FileInfo("VCD-report.xlsx"));
-            reportFileOption.AddAlias("-o");
-            reportFileOption.IsRequired = true;
-            this.AddOption(reportFileOption);
+            this.OutputReportOption = new Option<FileInfo>("--output-report", "-o")
+            {
+                Description = "The path to the report file",
+                DefaultValueFactory = _ => new FileInfo("VCD-report.xlsx"),
+                Required = true,
+            };
+            this.Options.Add(this.OutputReportOption);
+        }
+
+        /// <summary>
+        /// Binds the values parsed from the command line to the <see cref="Handler"/>
+        /// </summary>
+        /// <param name="handler">
+        /// The <see cref="Handler"/> that will execute the command
+        /// </param>
+        /// <param name="parseResult">
+        /// The <see cref="ParseResult"/> produced by parsing the command line arguments
+        /// </param>
+        public void BindTo(Handler handler, ParseResult parseResult)
+        {
+            handler.NoLogo = parseResult.GetValue(this.NoLogoOption);
+            handler.RequirementsFile = parseResult.GetValue(this.RequirementsFileOption);
+            handler.RequirementsSheetName = parseResult.GetValue(this.RequirementsSheetNameOption);
+            handler.RequirementsIdColumn = parseResult.GetValue(this.RequirementsIdColumnOption);
+            handler.RequirementsTextColumn = parseResult.GetValue(this.RequirementsTextColumnOption);
+            handler.SourceDirectory = parseResult.GetValue(this.SourceDirectoryOption);
+            handler.OutputReport = parseResult.GetValue(this.OutputReportOption);
         }
 
         /// <summary>
         /// The Command Handler of the <see cref="GenerateCommand"/>
         /// </summary>
-        public new class Handler : ICommandHandler
+        public class Handler
         {
             /// <summary>
             /// The (injected) <see cref="IRequirementsReader"/> that is used to read a set of requirements
@@ -152,15 +204,15 @@ namespace VCD.Generator.Commands
             /// </param>
             public Handler(IRequirementsReader requirementsReader, ITestResultReader resultReader, IMatchMaker matchMaker, IReportGenerator reportGenerator, ILogger<GenerateCommand>  logger)
             {
-                this.requirementsReader = requirementsReader 
+                this.requirementsReader = requirementsReader
                     ?? throw new ArgumentNullException(nameof(requirementsReader));
                 this.resultReader = resultReader
                     ?? throw new ArgumentNullException(nameof(resultReader));
                 this.reportGenerator = reportGenerator
                     ?? throw new ArgumentNullException(nameof(reportGenerator));
-                this.matchMaker = matchMaker 
+                this.matchMaker = matchMaker
                     ?? throw new ArgumentNullException(nameof(matchMaker));
-                this.logger = logger 
+                this.logger = logger
                     ?? throw new ArgumentNullException(nameof(logger));
             }
 
@@ -200,29 +252,12 @@ namespace VCD.Generator.Commands
             public FileInfo OutputReport { get; set; }
 
             /// <summary>
-            /// Invokes the <see cref="ICommandHandler"/>
+            /// Asynchronously executes the command
             /// </summary>
-            /// <param name="context">
-            /// The <see cref="InvocationContext"/> 
-            /// </param>
             /// <returns>
             /// 0 when successful, another if not
             /// </returns>
-            public int Invoke(InvocationContext context)
-            {
-                throw new NotSupportedException();
-            }
-
-            /// <summary>
-            /// Asynchronously invokes the <see cref="ICommandHandler"/>
-            /// </summary>
-            /// <param name="context">
-            /// The <see cref="InvocationContext"/> 
-            /// </param>
-            /// <returns>
-            /// 0 when successful, another if not
-            /// </returns>
-            public async Task<int> InvokeAsync(InvocationContext context)
+            public async Task<int> InvokeAsync()
             {
                 if (!this.NoLogo)
                 {
@@ -254,7 +289,7 @@ namespace VCD.Generator.Commands
 
                             ctx.Status("Reading Requirements at Warp 2...");
                             Thread.Sleep(1500);
-                            
+
                             IEnumerable<Requirement> requirements;
 
                             try
@@ -262,7 +297,7 @@ namespace VCD.Generator.Commands
                                 requirements = this.requirementsReader.Read(
                                     this.RequirementsFile,
                                     this.RequirementsSheetName,
-                                    this.RequirementsIdColumn, 
+                                    this.RequirementsIdColumn,
                                     this.RequirementsTextColumn);
                                 AnsiConsole.MarkupLine($"[grey]LOG:[/] A total of [bold]{requirements.Count()}[/] requirements were read");
                             }
@@ -303,14 +338,14 @@ namespace VCD.Generator.Commands
 
                             this.reportGenerator.Generate(requirements, this.OutputReport.FullName, ReportKind.SpreadSheet);
                             AnsiConsole.MarkupLine($"[grey]LOG:[/] VCD report generated at [bold]{this.OutputReport.FullName}[/]");
-                            
+
                             return Task.FromResult(0);
                         });
                 }
                 catch (Exception ex)
                 {
                     AnsiConsole.WriteLine();
-                    AnsiConsole.MarkupLine("[red]An exception occurred, please report an issue at[/]"); 
+                    AnsiConsole.MarkupLine("[red]An exception occurred, please report an issue at[/]");
                     AnsiConsole.MarkupLine("[link] https://github.com/RHEAGROUP/VCD-Generator/issues [/]");
                     AnsiConsole.WriteLine();
                     AnsiConsole.WriteException(ex);

--- a/VCD-Generator/Program.cs
+++ b/VCD-Generator/Program.cs
@@ -55,21 +55,21 @@ namespace VCD.Generator
         {
             var rootCommand = new GenerateCommand();
 
-            using var host = Host.CreateDefaultBuilder(args)
-                .UseSerilog((context, services, loggerConfiguration) => loggerConfiguration
-                    .ReadFrom.Configuration(context.Configuration))
-                .ConfigureServices((hostContext, services) =>
-                {
-                    services.AddSingleton<IRequirementsReader, RequirementsReader>();
-                    services.AddSingleton<ITestResultReader, TestResultReader>();
-                    services.AddSingleton<IMatchMaker, MatchMaker>();
-                    services.AddSingleton<IReportGenerator, ReportGenerator>();
-                    services.AddSingleton<GenerateCommand.Handler>();
-                })
-                .Build();
-
             rootCommand.SetAction(async (parseResult, cancellationToken) =>
             {
+                using var host = Host.CreateDefaultBuilder(args)
+                    .UseSerilog((context, services, loggerConfiguration) => loggerConfiguration
+                        .ReadFrom.Configuration(context.Configuration))
+                    .ConfigureServices((hostContext, services) =>
+                    {
+                        services.AddSingleton<IRequirementsReader, RequirementsReader>();
+                        services.AddSingleton<ITestResultReader, TestResultReader>();
+                        services.AddSingleton<IMatchMaker, MatchMaker>();
+                        services.AddSingleton<IReportGenerator, ReportGenerator>();
+                        services.AddSingleton<GenerateCommand.Handler>();
+                    })
+                    .Build();
+
                 var handler = host.Services.GetRequiredService<GenerateCommand.Handler>();
                 rootCommand.BindTo(handler, parseResult);
                 return await handler.InvokeAsync();

--- a/VCD-Generator/Program.cs
+++ b/VCD-Generator/Program.cs
@@ -1,35 +1,34 @@
-﻿// -------------------------------------------------------------------------------------------------
+// -------------------------------------------------------------------------------------------------
 // <copyright file="Program.cs" company="Starion Group S.A.">
-// 
+//
 //   Copyright 2022-2024 Starion Group S.A.
-// 
+//
 //   Licensed under the Apache License, Version 2.0 (the "License");
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
-// 
+//
 //        http://www.apache.org/licenses/LICENSE-2.0
-// 
+//
 //    Unless required by applicable law or agreed to in writing, software
 //    distributed under the License is distributed on an "AS IS" BASIS,
 //    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 //    See the License for the specific language governing permissions and
 //    limitations under the License.
-// 
+//
 // </copyright>
 // ------------------------------------------------------------------------------------------------
 
 namespace VCD.Generator
 {
-    using System.CommandLine.Builder;
+    using System.CommandLine;
     using System.CommandLine.Help;
-    using System.CommandLine.Hosting;
-    using System.CommandLine.Parsing;
-
+    using System.CommandLine.Invocation;
     using System.Linq;
+    using System.Threading.Tasks;
 
     using Microsoft.Extensions.DependencyInjection;
     using Microsoft.Extensions.Hosting;
- 
+
     using Serilog;
 
     using Spectre.Console;
@@ -52,51 +51,66 @@ namespace VCD.Generator
         /// <returns>
         /// the return code, 0 denotes success
         /// </returns>
-        public static int Main(string[] args)
+        public static async Task<int> Main(string[] args)
         {
-            var commandLineBuilder = BuildCommandLine()
-                .UseHost(_ => Host.CreateDefaultBuilder(args)
-                    .UseSerilog((context, services, loggerConfiguration) => loggerConfiguration
-                        .ReadFrom.Configuration(context.Configuration)
-                    ), builder => builder
-                    .ConfigureServices((hostContext, services) => 
-                    {
-                        services.AddSingleton<IRequirementsReader, RequirementsReader>();
-                        services.AddSingleton<ITestResultReader, TestResultReader>();
-                        services.AddSingleton<IMatchMaker, MatchMaker>();
-                        services.AddSingleton<IReportGenerator, ReportGenerator>();
-                    })
-                    .UseCommandHandler<GenerateCommand, GenerateCommand.Handler>())
-                .UseDefaults()
+            var rootCommand = new GenerateCommand();
+
+            using var host = Host.CreateDefaultBuilder(args)
+                .UseSerilog((context, services, loggerConfiguration) => loggerConfiguration
+                    .ReadFrom.Configuration(context.Configuration))
+                .ConfigureServices((hostContext, services) =>
+                {
+                    services.AddSingleton<IRequirementsReader, RequirementsReader>();
+                    services.AddSingleton<ITestResultReader, TestResultReader>();
+                    services.AddSingleton<IMatchMaker, MatchMaker>();
+                    services.AddSingleton<IReportGenerator, ReportGenerator>();
+                    services.AddSingleton<GenerateCommand.Handler>();
+                })
                 .Build();
 
-            return commandLineBuilder.Invoke(args);
+            rootCommand.SetAction(async (parseResult, cancellationToken) =>
+            {
+                var handler = host.Services.GetRequiredService<GenerateCommand.Handler>();
+                rootCommand.BindTo(handler, parseResult);
+                return await handler.InvokeAsync();
+            });
+
+            PrependLogoToHelp(rootCommand);
+
+            return await rootCommand.Parse(args).InvokeAsync();
         }
 
         /// <summary>
-        /// builds the root command
+        /// Replaces the default help action with one that prepends the ASCII logo.
         /// </summary>
-        /// <returns>
-        /// The <see cref="CommandLineBuilder"/> with the root command set
-        /// </returns>
-        private static CommandLineBuilder BuildCommandLine()
+        private static void PrependLogoToHelp(Command command)
         {
-            var root = new GenerateCommand();
-            
-            return new CommandLineBuilder(root)
-                .UseHelp(ctx =>
-                {
-                    ctx.HelpBuilder.CustomizeLayout(_ =>
-                        HelpBuilder.Default
-                            .GetLayout()
-                            .Skip(1) // Skip the default command description section.
-                            .Prepend(
-                                _ =>
-                                {
-                                    AnsiConsole.Markup($"[blue]{ResourceLoader.QueryLogo()}[/]");
-                                }
-                            ));
-                });
+            var helpOption = command.Options.OfType<HelpOption>().FirstOrDefault();
+
+            if (helpOption?.Action is SynchronousCommandLineAction defaultHelp)
+            {
+                helpOption.Action = new LogoHelpAction(defaultHelp);
+            }
+        }
+
+        /// <summary>
+        /// A <see cref="SynchronousCommandLineAction"/> that writes the ASCII logo before
+        /// delegating to the default help action.
+        /// </summary>
+        private sealed class LogoHelpAction : SynchronousCommandLineAction
+        {
+            private readonly SynchronousCommandLineAction inner;
+
+            public LogoHelpAction(SynchronousCommandLineAction inner)
+            {
+                this.inner = inner;
+            }
+
+            public override int Invoke(ParseResult parseResult)
+            {
+                AnsiConsole.Markup($"[blue]{ResourceLoader.QueryLogo()}[/]");
+                return this.inner.Invoke(parseResult);
+            }
         }
     }
 }

--- a/VCD-Generator/Program.cs
+++ b/VCD-Generator/Program.cs
@@ -1,7 +1,7 @@
 // -------------------------------------------------------------------------------------------------
 // <copyright file="Program.cs" company="Starion Group S.A.">
 //
-//   Copyright 2022-2024 Starion Group S.A.
+//   Copyright 2022-2026 Starion Group S.A.
 //
 //   Licensed under the Apache License, Version 2.0 (the "License");
 //   you may not use this file except in compliance with the License.

--- a/VCD-Generator/VCD-Generator.csproj
+++ b/VCD-Generator/VCD-Generator.csproj
@@ -3,7 +3,7 @@
     <PropertyGroup Label="Package">
         <Title>VCD Generator</Title>
         <Description>A Verification Control Document (VCD) generator.</Description>
-        <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
+        <TargetFramework>net10.0</TargetFramework>
         <OutputType>Exe</OutputType>
         <PackAsTool>true</PackAsTool>
         <PackageId>vcdg</PackageId>
@@ -49,15 +49,7 @@
         <PackageReference Include="ClosedXML" Version="0.105.0" />
     </ItemGroup>
 
-    <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
-        <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="8.0.1" />
-        <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.1" />
-        <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.2" />
-        <PackageReference Include="Serilog.Extensions.Hosting" Version="8.0.0" />
-        <PackageReference Include="Serilog.Settings.Configuration" Version="8.0.2" />
-    </ItemGroup>
-
-    <ItemGroup Condition="'$(TargetFramework)' == 'net10.0'">
+    <ItemGroup>
         <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="10.0.6" />
         <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.6" />
         <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.6" />

--- a/VCD-Generator/VCD-Generator.csproj
+++ b/VCD-Generator/VCD-Generator.csproj
@@ -3,7 +3,7 @@
     <PropertyGroup Label="Package">
         <Title>VCD Generator</Title>
         <Description>A Verification Control Document (VCD) generator.</Description>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
         <OutputType>Exe</OutputType>
         <PackAsTool>true</PackAsTool>
         <PackageId>vcdg</PackageId>

--- a/VCD-Generator/VCD-Generator.csproj
+++ b/VCD-Generator/VCD-Generator.csproj
@@ -41,8 +41,7 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="System.CommandLine" Version="2.0.0-beta4.22272.1" />
-        <PackageReference Include="System.CommandLine.Hosting" Version="0.4.0-alpha.22272.1" />
+        <PackageReference Include="System.CommandLine" Version="2.0.6" />
         <PackageReference Include="Serilog" Version="4.0.2" />
         <PackageReference Include="Serilog.Exceptions" Version="8.4.0" />
         <PackageReference Include="Serilog.Extensions.Hosting" Version="8.0.0" />
@@ -50,8 +49,9 @@
         <PackageReference Include="Serilog.Sinks.Console" Version="6.0.0" />
         <PackageReference Include="Spectre.Console" Version="0.49.1" />
         <PackageReference Include="ClosedXML" Version="0.105.0" />
-        <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="8.0.0" />
-        <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.1" />
+        <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="8.0.1" />
+        <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.1" />
+        <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.2" />
     </ItemGroup>
 
     <ItemGroup>

--- a/VCD-Generator/VCD-Generator.csproj
+++ b/VCD-Generator/VCD-Generator.csproj
@@ -49,7 +49,7 @@
         <PackageReference Include="Serilog.Settings.Configuration" Version="8.0.2" />
         <PackageReference Include="Serilog.Sinks.Console" Version="6.0.0" />
         <PackageReference Include="Spectre.Console" Version="0.49.1" />
-        <PackageReference Include="ClosedXML" Version="0.104.1" />
+        <PackageReference Include="ClosedXML" Version="0.105.0" />
         <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="8.0.0" />
         <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.1" />
     </ItemGroup>

--- a/VCD-Generator/VCD-Generator.csproj
+++ b/VCD-Generator/VCD-Generator.csproj
@@ -42,16 +42,27 @@
 
     <ItemGroup>
         <PackageReference Include="System.CommandLine" Version="2.0.6" />
-        <PackageReference Include="Serilog" Version="4.0.2" />
+        <PackageReference Include="Serilog" Version="4.3.1" />
         <PackageReference Include="Serilog.Exceptions" Version="8.4.0" />
-        <PackageReference Include="Serilog.Extensions.Hosting" Version="8.0.0" />
-        <PackageReference Include="Serilog.Settings.Configuration" Version="8.0.2" />
         <PackageReference Include="Serilog.Sinks.Console" Version="6.0.0" />
         <PackageReference Include="Spectre.Console" Version="0.49.1" />
         <PackageReference Include="ClosedXML" Version="0.105.0" />
+    </ItemGroup>
+
+    <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
         <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="8.0.1" />
         <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.1" />
         <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.2" />
+        <PackageReference Include="Serilog.Extensions.Hosting" Version="8.0.0" />
+        <PackageReference Include="Serilog.Settings.Configuration" Version="8.0.2" />
+    </ItemGroup>
+
+    <ItemGroup Condition="'$(TargetFramework)' == 'net10.0'">
+        <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="10.0.6" />
+        <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.6" />
+        <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.6" />
+        <PackageReference Include="Serilog.Extensions.Hosting" Version="10.0.0" />
+        <PackageReference Include="Serilog.Settings.Configuration" Version="10.0.0" />
     </ItemGroup>
 
     <ItemGroup>


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/STARIONGROUP/VCD-Generator/pulls) open
- [x] I have verified that I am following the VCD-Generator [code style guidelines](https://raw.githubusercontent.com/STARIONGROUP/VCD-Generator/master/.github/CONTRIBUTING.md)
- [x] I have provided test coverage for my change (where applicable)

### Use case

We have a .NET 10 project that wants to use `vcdg` as a global tool. On a machine whose only installed SDK is .NET 10, `dotnet tool install -g vcdg` currently fails at runtime:

```
You must install or update .NET to run this application.
App: …/vcdg
Framework: 'Microsoft.NETCore.App', version '8.0.0'
```

This PR switches `vcdg` to net10 so it installs and runs on .NET 10 without having to side-load a net8 runtime.

### Framework choice

Single LTS target: `net10.0` (Nov 2025, supported until Nov 2028). Per review feedback, net8.0 is dropped entirely rather than multi-targeted — the project moves forward on net10 only.

### Considered alternative: `<RollForward>Major</RollForward>`

Setting `RollForward=Major` on the net8 build would let the tool's apphost pick the net10 runtime at launch, satisfying the use case without changing the TFM. We chose against it because the tool would still ship only net8 assemblies (forgoing net10-aligned package fixes and keeping net8-line CVE liability), silent cross-major behavior changes (globalization, `System.Text.Json` defaults, `Assembly.Location` under single-file, TLS defaults) would surface only at runtime rather than at compile time, and the same config would also roll the tool forward into future unknown majors (net11, net12…) without a recompile. Moving the TFM verifies at build time that the code compiles and tests pass against the target runtime's reference assemblies — a stronger contract for a published NuGet tool with external consumers.

### Changes

1. **Target `net10.0`** — both csprojs set `<TargetFramework>net10.0</TargetFramework>`.
2. **CI** — `.github/workflows/CodeQuality.yml` installs `10.0.x` only, and refreshes `actions/checkout`, `setup-java`, `setup-dotnet`, `upload-artifact` to their current majors. The `@v3` of `upload-artifact` in particular was retired by GitHub in early 2025 and no longer functions on current runners, so this refresh is required for the workflow to run at all.
3. **Security** — `ClosedXML` 0.104.1 → 0.105.0 resolves two **High** severity advisories (`GHSA-f32c-w444-8ppv`, `GHSA-qj66-m88j-hmgj`) on the transitive `System.IO.Packaging 8.0.0`.
4. **`System.CommandLine` migration** — 2.0.0-beta4 (Jun 2022) → 2.0.6 GA, and drops `System.CommandLine.Hosting` 0.4.0-alpha (7 years in alpha, no GA companion):
   - `Program.cs` builds the generic `Host` lazily inside `SetAction` (so `--help` / `--version` / parse errors don't pay for DI + Serilog setup) and resolves the handler from it to bind parsed option values.
   - `GenerateCommand.cs` exposes options as public properties and adds `BindTo(Handler, ParseResult)`; all options use the 2.0 GA API (`new Option<T>(name, aliases…) { Description, Required, DefaultValueFactory }`).
   - `Handler` no longer implements `ICommandHandler`; the throwing `Invoke(InvocationContext)` is removed.
   - A custom `SynchronousCommandLineAction` preserves the ASCII-logo-on-`--help` behavior.
   - Test fixture drops the now-obsolete `Verify_that_GenerateCommand_Invoke_throws_exception` (12 tests, down from 13).
5. **Package versions aligned to net10** — runtime-aligned packages move to their net10 majors:

   | Package | Version |
   |---|---|
   | `Microsoft.Extensions.Configuration.Json` | 10.0.6 |
   | `Microsoft.Extensions.Hosting` | 10.0.6 |
   | `Microsoft.Extensions.Logging.Abstractions` | 10.0.6 |
   | `Microsoft.Extensions.Logging.Console` (tests) | 10.0.6 |
   | `Serilog.Extensions.Hosting` | 10.0.0 |
   | `Serilog.Settings.Configuration` | 10.0.0 |

6. **Runtime-agnostic bump** — `Serilog` 4.0.2 → 4.3.1 (required by `Serilog.Extensions.Hosting 10.0.0`).
7. **Copyright** — header year bumped to 2026 in `Program.cs` and `Commands/GenerateCommand.cs`.

### Verification

Builds clean (0 warnings / 0 errors) and tests pass:

```
Passed! - Failed: 0, Passed: 12, Skipped: 0, Total: 12 — VCD-Generator.Tests.dll (net10.0)
```

`dotnet list package --vulnerable --include-transitive` reports **no vulnerable packages**.

### Out of scope (pre-existing, flagged by review)

Kept for a separate cleanup PR to keep this one focused on the net10 migration:

- `Thread.Sleep(1500)` blocking calls inside the async spinner lambda (`GenerateCommand.cs`, in the Spectre `Status.Start` callback) — theatrical UX delays.
- Repeated `IEnumerable<T>.Count()` on reader results (potential re-enumeration of LINQ chains).
- Sequential disk reads of requirements file and test results (could be `Task.WhenAll`, currently serialized for spinner UX).
- `FileInfo.Exists` / `DirectoryInfo.Exists` TOCTOU pre-checks in `Handler.InvokeAsync`.
- Typo "nwe instance" in the `Handler` constructor XML doc.
- Four-level nesting inside `Handler.InvokeAsync` (method → try → spinner lambda → inner try/catch).

### Known CI caveat (pre-existing)

The workflow uses `SONAR_TOKEN` from repo secrets. GitHub does not pass secrets to `pull_request` workflows triggered from a fork, so the SonarCloud steps will fail on the CI run against this PR with a missing-token error. This is a pre-existing fork-PR limitation unrelated to the changes in this PR. The build/test steps run fine regardless; only the Sonar begin/end steps will be affected.

### Commits

1. `[Update] multi-target net8.0 and net10.0` — initial csproj TFM change (later collapsed to net10-only in commit 7).
2. `[Update] CI to install .NET 8 and .NET 10 SDKs and refresh action versions` — workflow changes (matrix trimmed to 10.0.x in commit 7).
3. `[Bump] ClosedXML to 0.105.0 to resolve high-severity advisories` — security fix.
4. `[Migrate] System.CommandLine from beta to 2.0 GA, remove dead .Hosting alpha` — parser migration + code rewrites.
5. `[Update] runtime-aligned packages with TFM-conditional ItemGroups` — per-TFM package splitting (conditions removed in commit 7).
6. `[Simplify] defer Host build and drop redundant defaults` — lazy Host build, drop redundant `false` factory, replace reflection-based source-directory default with `AppContext.BaseDirectory`.
7. `[Drop] net8.0 support, collapse to net10-only per PR review` — drops net8 target, removes TFM-conditional ItemGroups, trims CI matrix to 10.0.x, bumps copyright year.