### PR TITLE
[Add] --add-status-column flag for an aggregated, colour-coded outcome column

### DIFF
--- a/VCD-Generator.Tests/Commands/GenerateCommandHandlerTestFixture.cs
+++ b/VCD-Generator.Tests/Commands/GenerateCommandHandlerTestFixture.cs
@@ -106,7 +106,7 @@ namespace VCD.Generator.Tests.Commands
                 x => x.Match(It.IsAny<IEnumerable<Requirement>>(), It.IsAny<IEnumerable<TestCase>>()),
                 Times.Once);
 
-            this.reportGenerator.Verify(x => x.Generate(It.IsAny<IEnumerable<Requirement>>(), It.IsAny<string>(), ReportKind.SpreadSheet),
+            this.reportGenerator.Verify(x => x.Generate(It.IsAny<IEnumerable<Requirement>>(), It.IsAny<string>(), ReportKind.SpreadSheet, It.IsAny<bool>()),
                 Times.Once);
             
             Assert.That(result, Is.EqualTo(0));

--- a/VCD-Generator.Tests/Services/ReportGeneratorTestFixture.cs
+++ b/VCD-Generator.Tests/Services/ReportGeneratorTestFixture.cs
@@ -119,5 +119,60 @@ namespace VCD.Generator.Tests.Services
             Assert.That(() => this.reportGenerator.Generate(this.requirements, this.spreadsheetReportPath, ReportKind.Html),
                 Throws.TypeOf<NotImplementedException>());
         }
+
+        [Test]
+        public void Verify_that_spreadsheet_report_is_generated_with_status_column()
+        {
+            Assert.That(() => this.reportGenerator.Generate(this.requirements, this.spreadsheetReportPath, ReportKind.SpreadSheet, addStatusColumn: true),
+                Throws.Nothing);
+        }
+
+        [Test]
+        public void Verify_that_DeriveStatus_returns_empty_for_uncovered_requirement()
+        {
+            var requirement = new Requirement { Identifier = "REQ-99" };
+
+            Assert.That(ReportGenerator.DeriveStatus(requirement), Is.EqualTo(string.Empty));
+        }
+
+        [Test]
+        public void Verify_that_DeriveStatus_returns_Passed_when_every_test_case_is_Passed()
+        {
+            var requirement = new Requirement { Identifier = "REQ-99" };
+            requirement.TestCases.Add(new TestCase { FullName = "T1", Result = "Passed" });
+            requirement.TestCases.Add(new TestCase { FullName = "T2", Result = "Passed" });
+
+            Assert.That(ReportGenerator.DeriveStatus(requirement), Is.EqualTo("Passed"));
+        }
+
+        [Test]
+        public void Verify_that_DeriveStatus_returns_Failed_when_any_test_case_is_Failed()
+        {
+            var requirement = new Requirement { Identifier = "REQ-99" };
+            requirement.TestCases.Add(new TestCase { FullName = "T1", Result = "Passed" });
+            requirement.TestCases.Add(new TestCase { FullName = "T2", Result = "Failed" });
+
+            Assert.That(ReportGenerator.DeriveStatus(requirement), Is.EqualTo("Failed"));
+        }
+
+        [Test]
+        public void Verify_that_DeriveStatus_returns_Mixed_when_Passed_mixes_with_non_Passed_non_Failed()
+        {
+            var requirement = new Requirement { Identifier = "REQ-99" };
+            requirement.TestCases.Add(new TestCase { FullName = "T1", Result = "Passed" });
+            requirement.TestCases.Add(new TestCase { FullName = "T2", Result = "Inconclusive" });
+
+            Assert.That(ReportGenerator.DeriveStatus(requirement), Is.EqualTo("Mixed"));
+        }
+
+        [Test]
+        public void Verify_that_DeriveStatus_returns_Inconclusive_when_no_Passed_and_no_Failed()
+        {
+            var requirement = new Requirement { Identifier = "REQ-99" };
+            requirement.TestCases.Add(new TestCase { FullName = "T1", Result = "Inconclusive" });
+            requirement.TestCases.Add(new TestCase { FullName = "T2", Result = "Skipped" });
+
+            Assert.That(ReportGenerator.DeriveStatus(requirement), Is.EqualTo("Inconclusive"));
+        }
     }
 }

--- a/VCD-Generator/Commands/GenerateCommand.cs
+++ b/VCD-Generator/Commands/GenerateCommand.cs
@@ -76,6 +76,12 @@ namespace VCD.Generator.Commands
         public Option<FileInfo> OutputReportOption { get; }
 
         /// <summary>
+        /// The <see cref="Option{T}"/> that controls whether an aggregated, colour-coded
+        /// <c>STATUS</c> column is appended to the report.
+        /// </summary>
+        public Option<bool> AddStatusColumnOption { get; }
+
+        /// <summary>
         /// Initializes a new instance of the <see cref="GenerateCommand"/>
         /// </summary>
         public GenerateCommand() : base("VCD Generator")
@@ -127,6 +133,12 @@ namespace VCD.Generator.Commands
                 Required = true,
             };
             this.Options.Add(this.OutputReportOption);
+
+            this.AddStatusColumnOption = new Option<bool>("--add-status-column", "-st")
+            {
+                Description = "When set, appends a STATUS column to the report with an aggregated, colour-coded per-requirement outcome (empty = uncovered, Passed = green, Failed = red, Mixed = orange, Inconclusive = grey). Default: false.",
+            };
+            this.Options.Add(this.AddStatusColumnOption);
         }
 
         /// <summary>
@@ -147,6 +159,7 @@ namespace VCD.Generator.Commands
             handler.RequirementsTextColumn = parseResult.GetValue(this.RequirementsTextColumnOption);
             handler.SourceDirectory = parseResult.GetValue(this.SourceDirectoryOption);
             handler.OutputReport = parseResult.GetValue(this.OutputReportOption);
+            handler.AddStatusColumn = parseResult.GetValue(this.AddStatusColumnOption);
         }
 
         /// <summary>
@@ -247,6 +260,12 @@ namespace VCD.Generator.Commands
             public FileInfo OutputReport { get; set; }
 
             /// <summary>
+            /// Gets or sets a value indicating whether an aggregated, colour-coded <c>STATUS</c>
+            /// column is appended to the report.
+            /// </summary>
+            public bool AddStatusColumn { get; set; }
+
+            /// <summary>
             /// Asynchronously executes the command
             /// </summary>
             /// <returns>
@@ -331,7 +350,7 @@ namespace VCD.Generator.Commands
                             ctx.Status($"Generating report at Warp 11, Captain..., SLOW DOWN!");
                             Thread.Sleep(1500);
 
-                            this.reportGenerator.Generate(requirements, this.OutputReport.FullName, ReportKind.SpreadSheet);
+                            this.reportGenerator.Generate(requirements, this.OutputReport.FullName, ReportKind.SpreadSheet, this.AddStatusColumn);
                             AnsiConsole.MarkupLine($"[grey]LOG:[/] VCD report generated at [bold]{this.OutputReport.FullName}[/]");
 
                             return Task.FromResult(0);

--- a/VCD-Generator/Services/IReportGenerator.cs
+++ b/VCD-Generator/Services/IReportGenerator.cs
@@ -35,11 +35,17 @@ namespace VCD.Generator.Services
         /// The <see cref="Requirement"/> objects on the basis of which the report will be generated
         /// </param>
         /// <param name="filePath">
-        /// the file path(including file-name) where the report will be generated 
+        /// the file path(including file-name) where the report will be generated
         /// </param>
         /// <param name="reportKind">
         /// The kind of report that is generated
         /// </param>
-        void Generate(IEnumerable<Requirement> requirements, string filePath, ReportKind reportKind);
+        /// <param name="addStatusColumn">
+        /// When <c>true</c>, an additional <c>STATUS</c> column is written to the report with an
+        /// aggregated per-requirement outcome (empty / Passed / Failed / Mixed / Inconclusive) and
+        /// a matching background colour on the cell. Defaults to <c>false</c> to preserve the
+        /// pre-existing report schema.
+        /// </param>
+        void Generate(IEnumerable<Requirement> requirements, string filePath, ReportKind reportKind, bool addStatusColumn = false);
     }
 }

--- a/VCD-Generator/Services/ReportGenerator.cs
+++ b/VCD-Generator/Services/ReportGenerator.cs
@@ -23,6 +23,7 @@ namespace VCD.Generator.Services
     using System;
     using System.Collections.Generic;
     using System.Data;
+    using System.Linq;
     using System.Text;
 
     using ClosedXML.Excel;
@@ -61,17 +62,21 @@ namespace VCD.Generator.Services
         /// The <see cref="Requirement"/> objects on the basis of which the report will be generated
         /// </param>
         /// <param name="filePath">
-        /// the file path (including file-name) where the report will be generated 
+        /// the file path (including file-name) where the report will be generated
         /// </param>
         /// <param name="reportKind">
         /// The kind of report that is generated
         /// </param>
-        public void Generate(IEnumerable<Requirement> requirements, string filePath, ReportKind reportKind)
+        /// <param name="addStatusColumn">
+        /// When <c>true</c>, a <c>STATUS</c> column with an aggregated, colour-coded outcome per
+        /// requirement is appended to the report. See <see cref="DeriveStatus"/> for the rules.
+        /// </param>
+        public void Generate(IEnumerable<Requirement> requirements, string filePath, ReportKind reportKind, bool addStatusColumn = false)
         {
             switch (reportKind)
             {
                 case ReportKind.SpreadSheet:
-                    this.GenerateSpreadsheetReport(requirements,filePath);
+                    this.GenerateSpreadsheetReport(requirements, filePath, addStatusColumn);
                     break;
                 case ReportKind.Html:
                     this.GeneratedHtmlReport(requirements, filePath);
@@ -86,29 +91,39 @@ namespace VCD.Generator.Services
         /// The <see cref="Requirement"/> objects on the basis of which the report will be generated
         /// </param>
         /// <param name="filePath">
-        /// the file path (including file-name) where the report will be generated 
+        /// the file path (including file-name) where the report will be generated
         /// </param>
-        private void GenerateSpreadsheetReport(IEnumerable<Requirement> requirements, string filePath)
+        /// <param name="addStatusColumn">
+        /// When <c>true</c>, appends a <c>STATUS</c> column with the colour-coded per-requirement
+        /// outcome; see <see cref="DeriveStatus"/>.
+        /// </param>
+        private void GenerateSpreadsheetReport(IEnumerable<Requirement> requirements, string filePath, bool addStatusColumn)
         {
             this.logger.LogInformation("Creating target workbook");
 
             var wb = new XLWorkbook();
 
             var now = DateTime.UtcNow.ToString("yyyy-MM-dd");
-            
+
             var worksheet = wb.Worksheets.Add($"VCD-{now}");
 
             var dataTable = new DataTable();
             dataTable.Columns.Add("REQUIREMENT-ID", typeof(string));
             dataTable.Columns.Add("REQUIREMENT-TEXT", typeof(string));
             dataTable.Columns.Add("TESTCASES", typeof(string));
-            
-            foreach (var requirement in requirements)
+            if (addStatusColumn)
+            {
+                dataTable.Columns.Add("STATUS", typeof(string));
+            }
+
+            var materialisedRequirements = requirements as IList<Requirement> ?? requirements.ToList();
+
+            foreach (var requirement in materialisedRequirements)
             {
                 var dataRow = dataTable.NewRow();
                 dataRow["REQUIREMENT-ID"] = requirement.Identifier;
                 dataRow["REQUIREMENT-TEXT"] = requirement.Text;
-                
+
                 var sb = new StringBuilder();
 
                 foreach (var tc in requirement.TestCases)
@@ -117,6 +132,11 @@ namespace VCD.Generator.Services
                 }
 
                 dataRow["TESTCASES"] = sb.ToString();
+
+                if (addStatusColumn)
+                {
+                    dataRow["STATUS"] = DeriveStatus(requirement);
+                }
 
                 dataTable.Rows.Add(dataRow);
             }
@@ -130,6 +150,19 @@ namespace VCD.Generator.Services
             worksheet.Column("A").Width = 25;
             worksheet.Column("B").Width = 80;
 
+            if (addStatusColumn)
+            {
+                const int statusColumnIndex = 4;
+                worksheet.Column(statusColumnIndex).Style.Alignment.WrapText = false;
+                worksheet.Column(statusColumnIndex).Width = 15;
+
+                for (var i = 0; i < materialisedRequirements.Count; i++)
+                {
+                    var status = (string)dataTable.Rows[i]["STATUS"];
+                    ApplyStatusFill(worksheet.Cell(i + 2, statusColumnIndex), status);
+                }
+            }
+
             try
             {
                 worksheet.Rows().AdjustToContents();
@@ -142,6 +175,76 @@ namespace VCD.Generator.Services
 
             wb.SaveAs(filePath);
             this.logger.LogInformation("Target workbook saved to: {filePath}", filePath);
+        }
+
+        /// <summary>
+        /// Aggregates the outcome of every <see cref="TestCase"/> linked to a requirement into a
+        /// single status value suitable for filtering.
+        /// </summary>
+        /// <param name="requirement">
+        /// The <see cref="Requirement"/> whose test cases are aggregated.
+        /// </param>
+        /// <returns>
+        /// <list type="bullet">
+        ///   <item><description><c>""</c> — no test cases (the requirement is uncovered)</description></item>
+        ///   <item><description><c>"Failed"</c> — any test case has <c>Result == "Failed"</c></description></item>
+        ///   <item><description><c>"Passed"</c> — every test case has <c>Result == "Passed"</c></description></item>
+        ///   <item><description><c>"Mixed"</c> — at least one Passed and at least one non-Passed non-Failed</description></item>
+        ///   <item><description><c>"Inconclusive"</c> — no Passed and no Failed (e.g. only Skipped/Inconclusive)</description></item>
+        /// </list>
+        /// </returns>
+        public static string DeriveStatus(Requirement requirement)
+        {
+            if (requirement?.TestCases == null || requirement.TestCases.Count == 0)
+            {
+                return string.Empty;
+            }
+
+            if (requirement.TestCases.Any(tc => tc.Result == "Failed"))
+            {
+                return "Failed";
+            }
+
+            if (requirement.TestCases.All(tc => tc.Result == "Passed"))
+            {
+                return "Passed";
+            }
+
+            if (requirement.TestCases.Any(tc => tc.Result == "Passed"))
+            {
+                return "Mixed";
+            }
+
+            return "Inconclusive";
+        }
+
+        /// <summary>
+        /// Applies the conventional Excel "Good/Bad/Neutral" fill palette to a status cell so the
+        /// report is scannable at a glance.
+        /// </summary>
+        /// <param name="cell">
+        /// The <see cref="IXLCell"/> to colour.
+        /// </param>
+        /// <param name="status">
+        /// The aggregated status value produced by <see cref="DeriveStatus"/>.
+        /// </param>
+        private static void ApplyStatusFill(IXLCell cell, string status)
+        {
+            switch (status)
+            {
+                case "Passed":
+                    cell.Style.Fill.BackgroundColor = XLColor.FromHtml("#C6EFCE"); // light green
+                    break;
+                case "Failed":
+                    cell.Style.Fill.BackgroundColor = XLColor.FromHtml("#FFC7CE"); // light red
+                    break;
+                case "Mixed":
+                    cell.Style.Fill.BackgroundColor = XLColor.FromHtml("#FFEB9C"); // light orange
+                    break;
+                case "Inconclusive":
+                    cell.Style.Fill.BackgroundColor = XLColor.FromHtml("#D9D9D9"); // light grey
+                    break;
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
## Summary

Adds a `--add-status-column` (`-st`) CLI flag to the spreadsheet report. When enabled, vcdg appends a `STATUS` column with one of:

| Cell | Condition | Background |
|---|---|---|
| *(empty)* | No test cases — uncovered (default state) | none |
| `Passed` | Every test case has `Result == \"Passed\"` | light green (`#C6EFCE`) |
| `Failed` | Any test case has `Result == \"Failed\"` (failures dominate) | light red (`#FFC7CE`) |
| `Mixed` | At least one Passed and at least one non-Passed non-Failed | light orange (`#FFEB9C`) |
| `Inconclusive` | No Passed and no Failed (only Skipped/Inconclusive) | light grey (`#D9D9D9`) |

## Why

Today the `TESTCASES` column embeds outcome as free text (`\"Foo - Passed\\nBar - Failed\"`), which makes filtering \"show me what's not green\" awkward. A dedicated `STATUS` column with a colour fill turns the report into a one-glance status dashboard.

This is a strictly additive change — `--add-status-column` defaults to `false` so existing CLI invocations and downstream consumers (parsers, dashboards) see no schema change.

## What changed

- **`IReportGenerator.Generate`** — appended optional `bool addStatusColumn = false`. Source-compatible with all current callers.
- **`ReportGenerator.GenerateSpreadsheetReport`** — when the flag is set, appends a `STATUS` column to the `DataTable`, and after `InsertTable` walks the new column to apply the per-status background fill.
- **`ReportGenerator.DeriveStatus(Requirement)`** — new public static helper that exposes the aggregation rule so external consumers can reuse it.
- **`GenerateCommand`** — registers `--add-status-column` / `-st` and forwards to the handler.
- **Tests** — five new tests cover every branch of `DeriveStatus`, plus a smoke test for the spreadsheet path with the flag enabled. The existing Moq `Verify(... Generate(...))` was updated to the new four-parameter signature.

## Validation

- `dotnet test` — **19 passed, 0 failed** (was 13 passed; +6 new).

## Notes

- Colours match Excel's built-in \"Good/Bad/Neutral\" palette so they render cleanly under default themes.
- I wired the same logic locally (in the EMS repo's PowerShell post-processor) before opening this PR — the in-repo workaround is documented in [a decision record](https://bitbucket.csce.int/projects/EMS/repos/eda_ems/browse/documentation/decisions/vcd-generator-gherkin-support.md) (private link). Once this lands and a release ships, that workaround goes away.