### PR TITLE
[Add] CSV requirements input and VCD report output via Sep

### DIFF
--- a/VCD-Generator.Tests/Data/requirements.csv
+++ b/VCD-Generator.Tests/Data/requirements.csv
@@ -1,0 +1,6 @@
+Identifier,Requirement Text,Section Nr,Main Section,WP,Priority,User Journey,Verif Method,Compliance (Y/N/P),Actual Compliance(Y/N/P),Close out status,Comments
+REQ-01,The VCD Generator shall read the test results created by the NunitXml.TestLogger in the Nunit3 output format,1.1,VCD Generation,1,high,User Journey,Test,Y,Y,-,-
+  REQ-02  ,"Requirement text, with an embedded comma for RFC-4180 quoting",1.2,VCD Generation,2,high,User Journey,Test,Y,Y,-,-
+,Row with empty identifier should be skipped by the importer,1.3,VCD Generation,3,high,User Journey,Test,Y,Y,-,-
+REQ-03,"Line one of requirement
+Line two continues here",1.4,VCD Generation,4,high,User Journey,Test,Y,Y,-,-

--- a/VCD-Generator.Tests/Services/CsvReportGeneratorTestFixture.cs
+++ b/VCD-Generator.Tests/Services/CsvReportGeneratorTestFixture.cs
@@ -1,0 +1,200 @@
+// -------------------------------------------------------------------------------------------------
+// <copyright file="CsvReportGeneratorTestFixture.cs" company="Starion Group S.A.">
+//
+//   Copyright 2022-2024 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+namespace VCD.Generator.Tests.Services
+{
+    using System.Collections.Generic;
+    using System.IO;
+    using System.Linq;
+
+    using Microsoft.Extensions.Logging;
+
+    using nietras.SeparatedValues;
+
+    using NUnit.Framework;
+
+    using VCD.Generator.Services;
+
+    /// <summary>
+    /// Suite of tests for the <see cref="CsvReportGenerator"/> class
+    /// </summary>
+    [TestFixture]
+    public class CsvReportGeneratorTestFixture
+    {
+        private CsvReportGenerator csvReportGenerator;
+
+        private List<Requirement> requirements;
+
+        private string csvReportPath;
+
+        private ILoggerFactory loggerFactory;
+
+        [SetUp]
+        public void SetUp()
+        {
+            this.loggerFactory = LoggerFactory.Create(builder =>
+                builder.AddConsole().SetMinimumLevel(LogLevel.Trace));
+
+            this.csvReportPath = Path.Combine(Path.GetTempPath(), System.Guid.NewGuid().ToString("N") + ".csv");
+
+            this.csvReportGenerator = new CsvReportGenerator(this.loggerFactory);
+
+            this.CreateTestData();
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            if (File.Exists(this.csvReportPath))
+            {
+                File.Delete(this.csvReportPath);
+            }
+        }
+
+        private void CreateTestData()
+        {
+            this.requirements = new List<Requirement>();
+
+            var requirement_1 = new Requirement
+            {
+                Identifier = "REQ-01",
+                Text = "The VCD Generator shall read the test results created by the NunitXml.TestLogger in the Nunit3 output format"
+            };
+            this.requirements.Add(requirement_1);
+
+            var requirement_2 = new Requirement
+            {
+                Identifier = "REQ-02",
+                Text = "The VCD Generator shall read the requirements from an excel spreadsheet"
+            };
+            this.requirements.Add(requirement_2);
+
+            var testCase_1_1 = new TestCase
+            {
+                Name = "Verify_that_Read_throws_exception",
+                FullName = "VCD.Generator.Tests.Services.TestResultReaderTestFixture.Verify_that_Read_throws_exception",
+                Description = "Verifies that the TestResultReader.Read methods trows an exception",
+                RequirementId = new List<string> { "REQ-01" },
+                Result = "Passed"
+            };
+            requirement_1.TestCases.Add(testCase_1_1);
+
+            var testCase_1_2 = new TestCase
+            {
+                Name = "Verify_that_Read_does_not_throw_exception",
+                FullName = "VCD.Generator.Tests.Services.TestResultReaderTestFixture.Verify_that_Read_does_not_throw_exception",
+                Description = "Verifies that the TestResultReader.Read methods does not throw an exception",
+                RequirementId = new List<string> { "REQ-01" },
+                Result = "Passed"
+            };
+            requirement_1.TestCases.Add(testCase_1_2);
+
+            var testCase_2 = new TestCase
+            {
+                Name = "Verify_that_Read_throws_exception",
+                FullName = "VCD.Generator.Tests.Services.RequirementsReaderTestFixture.Verify_that_Read_throws_exception",
+                Description = "Verifies that the TestResultReader.Read methods trows an exception",
+                RequirementId = new List<string> { "REQ-02" },
+                Result = "Failed"
+            };
+            requirement_2.TestCases.Add(testCase_2);
+        }
+
+        [Test]
+        public void Verify_that_Generate_writes_header_row_and_rows()
+        {
+            this.csvReportGenerator.Generate(this.requirements, this.csvReportPath);
+
+            using var reader = Sep.Reader().FromFile(this.csvReportPath);
+
+            var header = reader.Header.ColNames.ToArray();
+            Assert.That(header, Is.EqualTo(new[] { "REQUIREMENT-ID", "REQUIREMENT-TEXT", "TESTCASES" }));
+
+            var rows = new List<string[]>();
+            foreach (var row in reader)
+            {
+                rows.Add(new[] { row[0].ToString(), row[1].ToString(), row[2].ToString() });
+            }
+
+            Assert.That(rows.Count, Is.EqualTo(this.requirements.Count));
+
+            for (var i = 0; i < this.requirements.Count; i++)
+            {
+                Assert.That(rows[i][0], Is.EqualTo(this.requirements[i].Identifier));
+            }
+        }
+
+        [Test]
+        public void Verify_that_TESTCASES_cell_contains_embedded_newlines()
+        {
+            var requirement = this.requirements[0];
+            var singleRequirement = new List<Requirement> { requirement };
+
+            this.csvReportGenerator.Generate(singleRequirement, this.csvReportPath);
+
+            using var reader = Sep.Reader(o => o with { Unescape = true }).FromFile(this.csvReportPath);
+
+            var testCasesCells = new List<string>();
+            foreach (var row in reader)
+            {
+                testCasesCells.Add(row["TESTCASES"].ToString());
+            }
+
+            Assert.That(testCasesCells.Count, Is.EqualTo(1));
+
+            var tc1 = requirement.TestCases[0];
+            var tc2 = requirement.TestCases[1];
+            var expected = $"{tc1.FullName} - {tc1.Result}\n{tc2.FullName} - {tc2.Result}";
+
+            Assert.That(testCasesCells[0], Is.EqualTo(expected));
+        }
+
+        [Test]
+        public void Verify_that_Generate_overwrites_existing_file()
+        {
+            this.csvReportGenerator.Generate(this.requirements, this.csvReportPath);
+
+            var secondBatch = new List<Requirement>
+            {
+                new Requirement
+                {
+                    Identifier = "REQ-99",
+                    Text = "Overwrite requirement"
+                }
+            };
+
+            this.csvReportGenerator.Generate(secondBatch, this.csvReportPath);
+
+            using var reader = Sep.Reader().FromFile(this.csvReportPath);
+
+            var ids = new List<string>();
+            var texts = new List<string>();
+            foreach (var row in reader)
+            {
+                ids.Add(row["REQUIREMENT-ID"].ToString());
+                texts.Add(row["REQUIREMENT-TEXT"].ToString());
+            }
+
+            Assert.That(ids.Count, Is.EqualTo(1));
+            Assert.That(ids[0], Is.EqualTo("REQ-99"));
+            Assert.That(texts[0], Is.EqualTo("Overwrite requirement"));
+        }
+    }
+}

--- a/VCD-Generator.Tests/Services/CsvRequirementsReaderTestFixture.cs
+++ b/VCD-Generator.Tests/Services/CsvRequirementsReaderTestFixture.cs
@@ -1,0 +1,137 @@
+// -------------------------------------------------------------------------------------------------
+// <copyright file="CsvRequirementsReaderTestFixture.cs" company="Starion Group S.A.">
+//
+//   Copyright 2022-2024 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+namespace VCD.Generator.Tests.Services
+{
+    using System.Linq;
+    using System.IO;
+
+    using Microsoft.Extensions.Logging;
+
+    using NUnit.Framework;
+
+    using VCD.Generator.Services;
+
+    /// <summary>
+    /// Suite of tests for the <see cref="CsvRequirementsReader"/> class
+    /// </summary>
+    [TestFixture]
+    public class CsvRequirementsReaderTestFixture
+    {
+        private CsvRequirementsReader requirementsReader;
+
+        private FileInfo requirementsDocumentFileInfo;
+
+        private ILoggerFactory loggerFactory;
+
+        [SetUp]
+        public void SetUp()
+        {
+            this.loggerFactory = LoggerFactory.Create(builder =>
+                builder.AddConsole().SetMinimumLevel(LogLevel.Trace));
+
+            this.requirementsDocumentFileInfo = new FileInfo(Path.Combine(TestContext.CurrentContext.WorkDirectory,
+                "Data", "requirements.csv"));
+
+            this.requirementsReader = new CsvRequirementsReader(this.loggerFactory);
+        }
+
+        [Test(Description = "Verifies that the CsvRequirementsReader.Read method returns the expected requirements"),
+         Property("REQUIREMENT-ID", "REQ-02")]
+        public void Verify_that_Read_with_default_first_column_returns_expected_requirements()
+        {
+            var requirements = this.requirementsReader.Read(this.requirementsDocumentFileInfo).ToList();
+
+            Assert.That(requirements, Is.Not.Empty);
+            Assert.That(requirements.Select(x => x.Identifier).ToList(),
+                Is.EqualTo(new[] { "REQ-01", "REQ-02", "REQ-03" }));
+        }
+
+        [Test]
+        public void Verify_that_Read_with_named_identifier_column_returns_expected_requirements()
+        {
+            var requirements = this.requirementsReader
+                .Read(this.requirementsDocumentFileInfo, null, "Identifier").ToList();
+
+            Assert.That(requirements.Select(x => x.Identifier).ToList(),
+                Is.EqualTo(new[] { "REQ-01", "REQ-02", "REQ-03" }));
+        }
+
+        [Test]
+        public void Verify_that_Read_with_named_text_column_populates_Text()
+        {
+            var requirements = this.requirementsReader
+                .Read(this.requirementsDocumentFileInfo, null, "Identifier", "Requirement Text").ToList();
+
+            Assert.That(requirements.Any(r => !string.IsNullOrEmpty(r.Text)), Is.True);
+
+            var multiline = requirements.Single(r => r.Identifier == "REQ-03");
+            Assert.That(multiline.Text, Does.Contain("\n"));
+            Assert.That(multiline.Text, Does.Contain("Line one of requirement"));
+            Assert.That(multiline.Text, Does.Contain("Line two continues here"));
+        }
+
+        [Test]
+        public void Verify_that_Read_with_unknown_identifier_column_throws_InvalidRequirementsFormatException()
+        {
+            Assert.That(
+                () => this.requirementsReader
+                    .Read(this.requirementsDocumentFileInfo, null, "NotAColumn").ToList(),
+                Throws.TypeOf<InvalidRequirementsFormatException>());
+        }
+
+        [Test]
+        public void Verify_that_Read_with_unknown_text_column_throws_InvalidRequirementsFormatException()
+        {
+            Assert.That(
+                () => this.requirementsReader
+                    .Read(this.requirementsDocumentFileInfo, null, "Identifier", "NotAColumn").ToList(),
+                Throws.TypeOf<InvalidRequirementsFormatException>());
+        }
+
+        [Test]
+        public void Verify_that_empty_identifier_rows_are_skipped()
+        {
+            var requirements = this.requirementsReader.Read(this.requirementsDocumentFileInfo).ToList();
+
+            Assert.That(requirements.Count, Is.EqualTo(3));
+        }
+
+        [Test]
+        public void Verify_that_identifier_is_trimmed()
+        {
+            var requirements = this.requirementsReader.Read(this.requirementsDocumentFileInfo).ToList();
+
+            foreach (var requirement in requirements)
+            {
+                Assert.That(requirement.Identifier, Is.EqualTo(requirement.Identifier.Trim()));
+            }
+        }
+
+        [Test]
+        public void Verify_that_sheetName_is_ignored_for_csv_input()
+        {
+            var requirements = this.requirementsReader
+                .Read(this.requirementsDocumentFileInfo, "AnySheet", "Identifier", "Requirement Text").ToList();
+
+            Assert.That(requirements.Count, Is.EqualTo(3));
+        }
+    }
+}

--- a/VCD-Generator.Tests/Services/ReportGeneratorTestFixture.cs
+++ b/VCD-Generator.Tests/Services/ReportGeneratorTestFixture.cs
@@ -52,7 +52,9 @@ namespace VCD.Generator.Tests.Services
 
             this.spreadsheetReportPath = Path.Combine(TestContext.CurrentContext.TestDirectory, "VCD-report.xlsx");
 
-            this.reportGenerator = new ReportGenerator(this.loggerFactory);
+            var csvReportGenerator = new CsvReportGenerator(this.loggerFactory);
+
+            this.reportGenerator = new ReportGenerator(csvReportGenerator, this.loggerFactory);
 
             this.CreateTestData();
         }

--- a/VCD-Generator.Tests/Services/RequirementsReaderDispatcherTestFixture.cs
+++ b/VCD-Generator.Tests/Services/RequirementsReaderDispatcherTestFixture.cs
@@ -1,0 +1,119 @@
+// -------------------------------------------------------------------------------------------------
+// <copyright file="RequirementsReaderDispatcherTestFixture.cs" company="Starion Group S.A.">
+//
+//   Copyright 2022-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+namespace VCD.Generator.Tests.Services
+{
+    using System.IO;
+    using System.Linq;
+
+    using Microsoft.Extensions.Logging;
+
+    using NUnit.Framework;
+
+    using VCD.Generator.Services;
+
+    /// <summary>
+    /// Suite of tests for the <see cref="RequirementsReaderDispatcher"/> class.
+    /// </summary>
+    /// <remarks>
+    /// Because the concrete <see cref="RequirementsReader.Read"/> and
+    /// <see cref="CsvRequirementsReader.Read"/> methods are not virtual, the dispatcher is
+    /// verified against real input files. Each routing assertion confirms that the expected
+    /// concrete reader executed by inspecting the shape of the returned requirements, which
+    /// differs between the xlsx and csv fixtures.
+    /// </remarks>
+    [TestFixture]
+    public class RequirementsReaderDispatcherTestFixture
+    {
+        private RequirementsReaderDispatcher dispatcher;
+
+        private FileInfo xlsxFileInfo;
+
+        private FileInfo csvFileInfo;
+
+        private ILoggerFactory loggerFactory;
+
+        [SetUp]
+        public void SetUp()
+        {
+            this.loggerFactory = LoggerFactory.Create(builder =>
+                builder.AddConsole().SetMinimumLevel(LogLevel.Trace));
+
+            this.xlsxFileInfo = new FileInfo(Path.Combine(TestContext.CurrentContext.WorkDirectory,
+                "Data", "Requirements-01.xlsx"));
+
+            this.csvFileInfo = new FileInfo(Path.Combine(TestContext.CurrentContext.WorkDirectory,
+                "Data", "requirements.csv"));
+
+            var xlsxReader = new RequirementsReader(this.loggerFactory);
+            var csvReader = new CsvRequirementsReader(this.loggerFactory);
+
+            this.dispatcher = new RequirementsReaderDispatcher(xlsxReader, csvReader, this.loggerFactory);
+        }
+
+        [Test]
+        public void Verify_that_csv_extension_routes_to_CsvRequirementsReader()
+        {
+            var requirements = this.dispatcher.Read(this.csvFileInfo).ToList();
+
+            // The csv fixture contains three requirements (REQ-01, REQ-02, REQ-03)
+            Assert.That(requirements.Count, Is.EqualTo(3));
+            Assert.That(requirements.Select(r => r.Identifier).ToList(),
+                Is.EqualTo(new[] { "REQ-01", "REQ-02", "REQ-03" }));
+        }
+
+        [Test]
+        public void Verify_that_xlsx_extension_routes_to_RequirementsReader()
+        {
+            var requirements = this.dispatcher.Read(this.xlsxFileInfo).ToList();
+
+            // The xlsx fixture contains two requirements
+            Assert.That(requirements.Count, Is.EqualTo(2));
+        }
+
+        [Test]
+        public void Verify_that_uppercase_extension_is_handled()
+        {
+            var uppercaseCopyPath = Path.Combine(TestContext.CurrentContext.WorkDirectory,
+                "Data", "requirements-uppercase.CSV");
+
+            File.Copy(this.csvFileInfo.FullName, uppercaseCopyPath, true);
+
+            try
+            {
+                var uppercaseFileInfo = new FileInfo(uppercaseCopyPath);
+
+                var requirements = this.dispatcher.Read(uppercaseFileInfo).ToList();
+
+                // Confirms csv routing: shape matches the csv fixture, not the xlsx fixture
+                Assert.That(requirements.Count, Is.EqualTo(3));
+                Assert.That(requirements.Select(r => r.Identifier).ToList(),
+                    Is.EqualTo(new[] { "REQ-01", "REQ-02", "REQ-03" }));
+            }
+            finally
+            {
+                if (File.Exists(uppercaseCopyPath))
+                {
+                    File.Delete(uppercaseCopyPath);
+                }
+            }
+        }
+    }
+}

--- a/VCD-Generator.Tests/VCD-Generator.Tests.csproj
+++ b/VCD-Generator.Tests/VCD-Generator.Tests.csproj
@@ -59,6 +59,9 @@
 		<None Update="Data\Requirements-02.xlsx">
 		  <CopyToOutputDirectory>Always</CopyToOutputDirectory>
 		</None>
+		<None Update="Data\requirements.csv">
+		  <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+		</None>
 		<None Update="Data\VCD-Generator.Tests.Result.xml">
 			<CopyToOutputDirectory>Always</CopyToOutputDirectory>
 		</None>

--- a/VCD-Generator/Commands/GenerateCommand.cs
+++ b/VCD-Generator/Commands/GenerateCommand.cs
@@ -331,7 +331,11 @@ namespace VCD.Generator.Commands
                             ctx.Status($"Generating report at Warp 11, Captain..., SLOW DOWN!");
                             Thread.Sleep(1500);
 
-                            this.reportGenerator.Generate(requirements, this.OutputReport.FullName, ReportKind.SpreadSheet);
+                            var reportKind = string.Equals(this.OutputReport.Extension, ".csv", StringComparison.OrdinalIgnoreCase)
+                                ? ReportKind.Csv
+                                : ReportKind.SpreadSheet;
+
+                            this.reportGenerator.Generate(requirements, this.OutputReport.FullName, reportKind);
                             AnsiConsole.MarkupLine($"[grey]LOG:[/] VCD report generated at [bold]{this.OutputReport.FullName}[/]");
 
                             return Task.FromResult(0);

--- a/VCD-Generator/Program.cs
+++ b/VCD-Generator/Program.cs
@@ -62,9 +62,12 @@ namespace VCD.Generator
                         .ReadFrom.Configuration(context.Configuration))
                     .ConfigureServices((hostContext, services) =>
                     {
-                        services.AddSingleton<IRequirementsReader, RequirementsReader>();
+                        services.AddSingleton<RequirementsReader>();
+                        services.AddSingleton<CsvRequirementsReader>();
+                        services.AddSingleton<IRequirementsReader, RequirementsReaderDispatcher>();
                         services.AddSingleton<ITestResultReader, TestResultReader>();
                         services.AddSingleton<IMatchMaker, MatchMaker>();
+                        services.AddSingleton<CsvReportGenerator>();
                         services.AddSingleton<IReportGenerator, ReportGenerator>();
                         services.AddSingleton<GenerateCommand.Handler>();
                     })

--- a/VCD-Generator/Services/CsvReportGenerator.cs
+++ b/VCD-Generator/Services/CsvReportGenerator.cs
@@ -1,0 +1,82 @@
+// -------------------------------------------------------------------------------------------------
+// <copyright file="CsvReportGenerator.cs" company="Starion Group S.A.">
+//
+//   Copyright 2022-2024 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+namespace VCD.Generator.Services
+{
+    using System.Collections.Generic;
+    using System.Linq;
+
+    using Microsoft.Extensions.Logging;
+    using Microsoft.Extensions.Logging.Abstractions;
+
+    using nietras.SeparatedValues;
+
+    /// <summary>
+    /// The purpose of the <see cref="CsvReportGenerator"/> is to generate a verification control document
+    /// report in CSV format. This is a helper class used by <see cref="ReportGenerator"/> and is not
+    /// intended to be an <see cref="IReportGenerator"/> implementation on its own.
+    /// </summary>
+    public class CsvReportGenerator
+    {
+        /// <summary>
+        /// The <see cref="ILogger"/> used to log
+        /// </summary>
+        private readonly ILogger<CsvReportGenerator> logger;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="CsvReportGenerator"/> class.
+        /// </summary>
+        /// <param name="loggerFactory">
+        /// The (injected) <see cref="ILoggerFactory"/> used to setup logging
+        /// </param>
+        public CsvReportGenerator(ILoggerFactory loggerFactory = null)
+        {
+            this.logger = loggerFactory == null ? NullLogger<CsvReportGenerator>.Instance : loggerFactory.CreateLogger<CsvReportGenerator>();
+        }
+
+        /// <summary>
+        /// Generates a CSV VCD report at the specified location.
+        /// </summary>
+        /// <param name="requirements">
+        /// The <see cref="Requirement"/> objects on the basis of which the report will be generated
+        /// </param>
+        /// <param name="filePath">
+        /// the file path (including file-name) where the report will be generated
+        /// </param>
+        public void Generate(IEnumerable<Requirement> requirements, string filePath)
+        {
+            this.logger.LogInformation("Creating CSV report at {filePath}", filePath);
+
+            using var writer = Sep.Writer(o => o with { Sep = new Sep(','), Escape = true }).ToFile(filePath);
+
+            foreach (var requirement in requirements)
+            {
+                var testCases = string.Join("\n", requirement.TestCases.Select(tc => $"{tc.FullName} - {tc.Result}"));
+
+                using var row = writer.NewRow();
+                row["REQUIREMENT-ID"].Set(requirement.Identifier);
+                row["REQUIREMENT-TEXT"].Set(requirement.Text);
+                row["TESTCASES"].Set(testCases);
+            }
+
+            this.logger.LogInformation("CSV report saved to: {filePath}", filePath);
+        }
+    }
+}

--- a/VCD-Generator/Services/CsvRequirementsReader.cs
+++ b/VCD-Generator/Services/CsvRequirementsReader.cs
@@ -1,0 +1,138 @@
+// -------------------------------------------------------------------------------------------------
+// <copyright file="CsvRequirementsReader.cs" company="Starion Group S.A.">
+//
+//   Copyright 2022-2024 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+namespace VCD.Generator.Services
+{
+    using System.Collections.Generic;
+    using System.IO;
+
+    using Microsoft.Extensions.Logging;
+    using Microsoft.Extensions.Logging.Abstractions;
+
+    using nietras.SeparatedValues;
+
+    /// <summary>
+    /// The purpose of the <see cref="CsvRequirementsReader"/> is to read the list of requirements from a CSV file
+    /// </summary>
+    /// <remarks>
+    /// The input is a CSV file where the column that holds the requirement identifier (and optionally the
+    /// requirement text) is specified by header name. The separator is auto-detected by the Sep library.
+    /// </remarks>
+    public class CsvRequirementsReader : IRequirementsReader
+    {
+        /// <summary>
+        /// The <see cref="ILogger"/> used to log
+        /// </summary>
+        private readonly ILogger<CsvRequirementsReader> logger;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="CsvRequirementsReader"/> class.
+        /// </summary>
+        /// <param name="loggerFactory">
+        /// The (injected) <see cref="ILoggerFactory"/> used to setup logging
+        /// </param>
+        public CsvRequirementsReader(ILoggerFactory loggerFactory = null)
+        {
+            this.logger = loggerFactory == null ? NullLogger<CsvRequirementsReader>.Instance : loggerFactory.CreateLogger<CsvRequirementsReader>();
+        }
+
+        /// <summary>
+        /// Reads the <see cref="Requirement"/>s from the specified CSV file
+        /// </summary>
+        /// <param name="fileInfo">
+        /// The <see cref="FileInfo"/> to the requirements input file
+        /// </param>
+        /// <param name="sheetName">
+        /// Ignored for CSV input. When a non-empty value is supplied a debug log entry is emitted and the value is discarded.
+        /// </param>
+        /// <param name="identifierColumnName">
+        /// The name of the header column where the unique identifier of the requirements is located. When this is null
+        /// or empty, the first column is used.
+        /// </param>
+        /// <param name="textColumnName">
+        /// The name of the header column where the requirement text is located. When this is null the requirement text
+        /// is ignored and remains an empty string.
+        /// </param>
+        /// <returns>
+        /// A fully materialised <see cref="IEnumerable{Requirement}"/>
+        /// </returns>
+        public IEnumerable<Requirement> Read(FileInfo fileInfo, string sheetName = null, string identifierColumnName = null, string textColumnName = null)
+        {
+            if (!string.IsNullOrEmpty(sheetName))
+            {
+                this.logger.LogDebug("sheetName '{sheetName}' ignored for CSV input", sheetName);
+            }
+
+            var results = new List<Requirement>();
+
+            using var reader = Sep.Reader().FromFile(fileInfo.FullName);
+
+            int requirementIdColumnIndex;
+            if (string.IsNullOrEmpty(identifierColumnName))
+            {
+                requirementIdColumnIndex = 0;
+            }
+            else
+            {
+                if (!reader.Header.TryIndexOf(identifierColumnName, out requirementIdColumnIndex))
+                {
+                    throw new InvalidRequirementsFormatException($"The identifier column with name \"{identifierColumnName}\" could not be found");
+                }
+            }
+
+            var requirementTextColumnIndex = -1;
+            if (textColumnName != null)
+            {
+                if (!reader.Header.TryIndexOf(textColumnName, out requirementTextColumnIndex))
+                {
+                    throw new InvalidRequirementsFormatException($"The text column with name \"{textColumnName}\" could not be found");
+                }
+            }
+
+            foreach (var row in reader)
+            {
+                var identifier = row[requirementIdColumnIndex].ToString();
+
+                if (string.IsNullOrWhiteSpace(identifier))
+                {
+                    continue;
+                }
+
+                var text = string.Empty;
+                if (textColumnName != null)
+                {
+                    text = row[requirementTextColumnIndex].ToString();
+                }
+
+                this.logger.LogDebug("requirement found: {identifier}", identifier);
+
+                var requirement = new Requirement
+                {
+                    Identifier = identifier.Trim(),
+                    Text = text
+                };
+
+                results.Add(requirement);
+            }
+
+            return results;
+        }
+    }
+}

--- a/VCD-Generator/Services/ReportGenerator.cs
+++ b/VCD-Generator/Services/ReportGenerator.cs
@@ -44,13 +44,22 @@ namespace VCD.Generator.Services
         private readonly ILogger<ReportGenerator> logger;
 
         /// <summary>
+        /// The <see cref="CsvReportGenerator"/> used to generate CSV reports
+        /// </summary>
+        private readonly CsvReportGenerator csvReportGenerator;
+
+        /// <summary>
         /// Initializes a new instance of the <see cref="TestResultReader"/> class.
         /// </summary>
+        /// <param name="csvReportGenerator">
+        /// The (injected) <see cref="CsvReportGenerator"/> used to generate CSV reports
+        /// </param>
         /// <param name="loggerFactory">
         /// The (injected) <see cref="ILoggerFactory"/> used to setup logging
         /// </param>
-        public ReportGenerator(ILoggerFactory loggerFactory = null)
+        public ReportGenerator(CsvReportGenerator csvReportGenerator, ILoggerFactory loggerFactory = null)
         {
+            this.csvReportGenerator = csvReportGenerator ?? throw new ArgumentNullException(nameof(csvReportGenerator));
             this.logger = loggerFactory == null ? NullLogger<ReportGenerator>.Instance : loggerFactory.CreateLogger<ReportGenerator>();
         }
 
@@ -75,6 +84,9 @@ namespace VCD.Generator.Services
                     break;
                 case ReportKind.Html:
                     this.GeneratedHtmlReport(requirements, filePath);
+                    break;
+                case ReportKind.Csv:
+                    this.csvReportGenerator.Generate(requirements, filePath);
                     break;
             }
         }

--- a/VCD-Generator/Services/ReportKind.cs
+++ b/VCD-Generator/Services/ReportKind.cs
@@ -31,6 +31,11 @@ namespace VCD.Generator.Services
         SpreadSheet,
 
         /// <summary>
+        /// Assertion that the report kind is a CSV file
+        /// </summary>
+        Csv,
+
+        /// <summary>
         /// Assertion that the report kind is an HTML
         /// </summary>
         Html

--- a/VCD-Generator/Services/RequirementsReaderDispatcher.cs
+++ b/VCD-Generator/Services/RequirementsReaderDispatcher.cs
@@ -1,0 +1,116 @@
+// -------------------------------------------------------------------------------------------------
+// <copyright file="RequirementsReaderDispatcher.cs" company="Starion Group S.A.">
+//
+//   Copyright 2022-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+namespace VCD.Generator.Services
+{
+    using System;
+    using System.Collections.Generic;
+    using System.IO;
+
+    using Microsoft.Extensions.Logging;
+    using Microsoft.Extensions.Logging.Abstractions;
+
+    /// <summary>
+    /// The purpose of the <see cref="RequirementsReaderDispatcher"/> is to delegate the reading of
+    /// requirements to the appropriate concrete <see cref="IRequirementsReader"/> implementation
+    /// based on the file extension of the provided input file.
+    /// </summary>
+    /// <remarks>
+    /// Files with a <c>.csv</c> extension are routed to the <see cref="CsvRequirementsReader"/>.
+    /// Any other extension (including <c>.xlsx</c>, empty or unknown extensions) is routed to the
+    /// spreadsheet-based <see cref="RequirementsReader"/>.
+    /// </remarks>
+    public class RequirementsReaderDispatcher : IRequirementsReader
+    {
+        /// <summary>
+        /// The (injected) <see cref="RequirementsReader"/> used for spreadsheet (xlsx) input
+        /// </summary>
+        private readonly RequirementsReader xlsxReader;
+
+        /// <summary>
+        /// The (injected) <see cref="CsvRequirementsReader"/> used for CSV input
+        /// </summary>
+        private readonly CsvRequirementsReader csvReader;
+
+        /// <summary>
+        /// The <see cref="ILogger"/> used to log
+        /// </summary>
+        private readonly ILogger<RequirementsReaderDispatcher> logger;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="RequirementsReaderDispatcher"/> class.
+        /// </summary>
+        /// <param name="xlsxReader">
+        /// The (injected) <see cref="RequirementsReader"/> used when the input file is an xlsx spreadsheet
+        /// </param>
+        /// <param name="csvReader">
+        /// The (injected) <see cref="CsvRequirementsReader"/> used when the input file is a CSV file
+        /// </param>
+        /// <param name="loggerFactory">
+        /// The (injected) <see cref="ILoggerFactory"/> used to setup logging
+        /// </param>
+        /// <exception cref="ArgumentNullException">
+        /// Thrown when <paramref name="xlsxReader"/> or <paramref name="csvReader"/> is <c>null</c>.
+        /// </exception>
+        public RequirementsReaderDispatcher(RequirementsReader xlsxReader, CsvRequirementsReader csvReader, ILoggerFactory loggerFactory = null)
+        {
+            this.xlsxReader = xlsxReader
+                ?? throw new ArgumentNullException(nameof(xlsxReader));
+            this.csvReader = csvReader
+                ?? throw new ArgumentNullException(nameof(csvReader));
+            this.logger = loggerFactory == null ? NullLogger<RequirementsReaderDispatcher>.Instance : loggerFactory.CreateLogger<RequirementsReaderDispatcher>();
+        }
+
+        /// <summary>
+        /// Reads the <see cref="Requirement"/>s from the specified file by dispatching to the
+        /// concrete <see cref="IRequirementsReader"/> that matches the file extension.
+        /// </summary>
+        /// <param name="fileInfo">
+        /// The <see cref="FileInfo"/> to the requirements input file
+        /// </param>
+        /// <param name="sheetName">
+        /// The name of the sheet where the requirements are located, in case this is null the first sheet in the
+        /// workbook is used. Ignored when the input is a CSV file.
+        /// </param>
+        /// <param name="identifierColumnName">
+        /// The name of the column where the unique identifier of the requirements is located, in case
+        /// this is null, the first used column is used
+        /// </param>
+        /// <param name="textColumnName">
+        /// The name of the column where the requirement text is located. In case this is null the requirement text is ignored
+        /// </param>
+        /// <returns>
+        /// An <see cref="IEnumerable{Requirement}"/>
+        /// </returns>
+        public IEnumerable<Requirement> Read(FileInfo fileInfo, string sheetName = null, string identifierColumnName = null, string textColumnName = null)
+        {
+            var extension = fileInfo.Extension.ToLowerInvariant();
+
+            if (extension == ".csv")
+            {
+                this.logger.LogDebug("dispatching {fileName} to {reader}", fileInfo.Name, "CSV");
+                return this.csvReader.Read(fileInfo, sheetName, identifierColumnName, textColumnName);
+            }
+
+            this.logger.LogDebug("dispatching {fileName} to {reader}", fileInfo.Name, "xlsx");
+            return this.xlsxReader.Read(fileInfo, sheetName, identifierColumnName, textColumnName);
+        }
+    }
+}

--- a/VCD-Generator/VCD-Generator.csproj
+++ b/VCD-Generator/VCD-Generator.csproj
@@ -47,6 +47,7 @@
         <PackageReference Include="Serilog.Sinks.Console" Version="6.0.0" />
         <PackageReference Include="Spectre.Console" Version="0.49.1" />
         <PackageReference Include="ClosedXML" Version="0.105.0" />
+        <PackageReference Include="Sep" Version="0.12.5" />
     </ItemGroup>
 
     <ItemGroup>


### PR DESCRIPTION
## Why

Right now the generator only eats `.xlsx`. That's fine when your requirements live in a shared drive — but the moment you want to check them into the same repo as your code, xlsx stops being your friend:

- **Binary blob.** Git can't diff it, can't meaningfully merge it, and it bloats the repo every time someone opens it in Excel and hits save.
- **Impossible reviews.** A PR that tweaks a requirement shows up as "Requirements.xlsx changed" — no clue what actually changed.
- **Merge conflicts = pain.** Two people edit the sheet, one of them loses.

CSV fixes all three. It's plain text, diffs beautifully, and a requirements edit becomes a proper one-line change in a PR.

So this PR teaches the tool to read and write CSV alongside xlsx. No flags, no flags to remember — it just looks at the file extension:

- `--requirements-file requirements.csv` → reads CSV
- `--output-report VCD.csv` → writes CSV
- Anything else → stays on the xlsx path, exactly as before

## How

- New `CsvRequirementsReader` + `CsvReportGenerator` using [Sep](https://github.com/nietras/Sep) (MIT, AOT-friendly, explicitly targets net10)
- A tiny `RequirementsReaderDispatcher` picks the right reader based on the input extension
- `ReportGenerator` grew a `ReportKind.Csv` branch that delegates to the CSV writer
- `GenerateCommand` derives the `ReportKind` from the output extension
- `--requirements-sheet-name` is silently ignored when the input is CSV (sheets don't exist in CSV land)
- RFC-4180 quoting handled by Sep — embedded commas, quotes, and newlines round-trip correctly

## Why Sep and not CsvHelper

CsvHelper is the obvious default — it's the most-starred CSV library in the .NET world. But looking at its current csproj it still targets `net9.0; net8.0; netstandard2.1; netstandard2.0; net48; net47; net462` and has no `net10.0` target yet. .NET 10 is an LTS release and this project just migrated to it (PR #9) — a library that hasn't updated for the new LTS within this window is a yellow flag for long-term maintenance, especially in security-sensitive contexts where stale dependencies accumulate CVE exposure.

Sep, by contrast, explicitly targets `net10.0; net9.0; net8.0` today, is AOT/trim-compatible, and its maintainer tracks runtime releases aggressively. Same MIT license, comparable community footprint (1.4k stars, actively pushed). Switching back to CsvHelper later is trivial if that trade-off calculus ever flips.

## What's in the diff

**New files**
- `VCD-Generator/Services/CsvRequirementsReader.cs`
- `VCD-Generator/Services/CsvReportGenerator.cs`
- `VCD-Generator/Services/RequirementsReaderDispatcher.cs`
- `VCD-Generator.Tests/Services/CsvRequirementsReaderTestFixture.cs` (8 tests)
- `VCD-Generator.Tests/Services/CsvReportGeneratorTestFixture.cs` (3 tests)
- `VCD-Generator.Tests/Services/RequirementsReaderDispatcherTestFixture.cs` (3 tests)
- `VCD-Generator.Tests/Data/requirements.csv` (covers trim, empty-id skip, and embedded-newline quoting)

**Touched files**
- `ReportKind.cs` — added `Csv` enum value
- `ReportGenerator.cs` — new ctor dep + Csv case in the switch
- `Program.cs` — DI wiring for the three new services
- `GenerateCommand.cs` — extension-based `ReportKind` selection
- `VCD-Generator.csproj` — `<PackageReference Include="Sep" Version="0.12.5" />`

## Test plan

- [x] `dotnet build` — clean on net10.0
- [x] `dotnet test` — 29/29 passing (14 new, 15 pre-existing)
- [x] Manual smoke: `.xlsx` in → `.csv` out
- [x] Manual smoke: `.csv` in → `.xlsx` out
- [ ] Reviewer sanity-check: extension-based dispatch vs an explicit `--format` flag — I went with extensions to avoid adding CLI surface, happy to change if you'd rather be explicit

## Open questions for reviewers

1. **Library choice.** Sep over CsvHelper — reasoning above. Swap if you disagree.
2. **ClosedXML stays.** No attempt to migrate the xlsx path to OpenXML SDK — out of scope.
3. **Sheet name on CSV input.** Currently silently ignored. I could make it throw instead if you want strict validation.